### PR TITLE
Re-routing ember route structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+/vendor/bundle
 
 .DS_Store
 # Ignore all logfiles and tempfiles.
@@ -13,6 +14,9 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+*~
+*.swp
+*.swo
 
 /node_modules
 /yarn-error.log

--- a/app/controllers/api/companies_controller.rb
+++ b/app/controllers/api/companies_controller.rb
@@ -1,11 +1,17 @@
 class Api::CompaniesController < ApplicationController
+  # GET /companies
   def index
     company_name = params[:name]
-
     @companies = Company.all
 
     @companies = Company.where("name = ?", company_name) if company_name.present?
 
     render :json => @companies
+  end
+
+  # GET /companies/:id
+  def show
+    @company = Company.find(params[:id])
+    render :json => @company
   end
 end

--- a/app/controllers/api/coop_positions_controller.rb
+++ b/app/controllers/api/coop_positions_controller.rb
@@ -1,4 +1,5 @@
 class Api::CoopPositionsController < ApplicationController
+  # GET /coop_positions
   def index
     company_id = params[:company_id]
     @coop_positions = CoopPosition.all
@@ -6,5 +7,11 @@ class Api::CoopPositionsController < ApplicationController
     @coop_positions = CoopPosition.where("company_id = ?", company_id) if company_id.present?
 
     render :json => @coop_positions
+  end
+
+  # GET /coop_positions/:id
+  def show
+    @coop_position = CoopPosition.find(params[:id])
+    render :json => @coop_position
   end
 end

--- a/app/controllers/api/students_controller.rb
+++ b/app/controllers/api/students_controller.rb
@@ -1,4 +1,5 @@
 class Api::StudentsController < ApplicationController
+  # GET /students
   def index
     position_title = params[:position_title]
     company_id = params[:company_id]
@@ -8,5 +9,11 @@ class Api::StudentsController < ApplicationController
     @students = Student.joins(:coop_positions).where(coop_positions: { company_id: company_id, position_title: position_title }) if company_id.present? && position_title.present?
     
     render :json => @students
+  end
+
+  # GET /students/:id
+  def show
+    @company = Student.find(params[:id])
+    render :json => @company
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,4 +1,3 @@
 class Company < ActiveRecord::Base
-  #has_many :students
   has_many :coop_positions
 end

--- a/app/models/coop_position.rb
+++ b/app/models/coop_position.rb
@@ -1,5 +1,4 @@
 class CoopPosition < ActiveRecord::Base
-  has_one :student
-  #has_many :students
+  belongs_to :student
   belongs_to :company
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,4 +1,3 @@
 class Student < ActiveRecord::Base
   has_many :coop_positions
-  #has_many :companies
 end

--- a/app/serializers/company_serializer.rb
+++ b/app/serializers/company_serializer.rb
@@ -1,5 +1,4 @@
 class CompanySerializer < ActiveModel::Serializer
   attributes :name
-  #has_many :students
   has_many :coop_positions
 end

--- a/app/serializers/coop_position_serializer.rb
+++ b/app/serializers/coop_position_serializer.rb
@@ -1,6 +1,5 @@
 class CoopPositionSerializer < ActiveModel::Serializer
   attributes :position_title, :period_of_work, :location, :review, :star_rating
-  #has_many :students
-  #has_one :student
+  belongs_to :student
   belongs_to :company
 end

--- a/app/serializers/student_serializer.rb
+++ b/app/serializers/student_serializer.rb
@@ -1,5 +1,4 @@
 class StudentSerializer < ActiveModel::Serializer
   attributes :name, :contact
   has_many :coop_positions
-  #has_many :companies
 end

--- a/frontend/app/adapters/application.js
+++ b/frontend/app/adapters/application.js
@@ -1,5 +1,11 @@
 import DS from 'ember-data';
+import { underscore } from '@ember/string';
+import { pluralize } from 'ember-inflector';
 
 export default DS.JSONAPIAdapter.extend({
-  namespace: 'api'
+  namespace: 'api',
+
+  pathForType(type) {
+    return pluralize(underscore(type));
+  }
 });

--- a/frontend/app/models/coop-position.js
+++ b/frontend/app/models/coop-position.js
@@ -7,6 +7,6 @@ export default DS.Model.extend({
   review: DS.attr(),
   starRating: DS.attr(),
 
-  students: DS.belongsTo('student'),
+  student: DS.belongsTo('student'),
   company: DS.belongsTo('company')
 });

--- a/frontend/app/router.js
+++ b/frontend/app/router.js
@@ -7,9 +7,15 @@ const Router = EmberRouter.extend({
 });
 
 Router.map(function() {
-	this.route('students');
-	this.route('companies');
-	this.route('coop-positions');
+  this.route('companies', function() {
+    this.route('company', { path: '/:company_id' }, function() {
+      this.route('coop-positions', function() {
+        this.route('coop-position', { path: '/coop-positions/:coop_position_id' }, function() {
+          this.route('students');
+        });
+      });
+    });
+  });
 });
 
 export default Router;

--- a/frontend/app/routes/companies/company.js
+++ b/frontend/app/routes/companies/company.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  model(params) {
+    return this.store.findRecord('company', params.company_id);
+  }
+});

--- a/frontend/app/routes/companies/company/coop-positions.js
+++ b/frontend/app/routes/companies/company/coop-positions.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  model() {
+    let company = this.modelFor('companies/company');
+    return company.get('coopPositions');
+  }
+});

--- a/frontend/app/routes/companies/company/coop-positions/coop-position.js
+++ b/frontend/app/routes/companies/company/coop-positions/coop-position.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  model(params) {
+    return this.store.findRecord('coop-position', params.coop_position_id);
+  }
+});

--- a/frontend/app/routes/companies/company/coop-positions/coop-position/students.js
+++ b/frontend/app/routes/companies/company/coop-positions/coop-position/students.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   model() {
-    //let position = this.modelFor('coop-positions/coop-position');???
-    //return position.get('students');???
+    let position = this.modelFor('companies/company/coop-positions/coop-position');
+    return position.get('student');
   }
 });

--- a/frontend/app/routes/companies/company/coop-positions/coop-position/students.js
+++ b/frontend/app/routes/companies/company/coop-positions/coop-position/students.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  model() {
+    //let position = this.modelFor('coop-positions/coop-position');???
+    //return position.get('students');???
+  }
+});

--- a/frontend/app/routes/coop-positions.js
+++ b/frontend/app/routes/coop-positions.js
@@ -1,7 +1,0 @@
-import Route from '@ember/routing/route';
-
-export default Route.extend({
-  model() {
-    return this.store.findAll('coop-position');
-  }
-});

--- a/frontend/app/routes/students.js
+++ b/frontend/app/routes/students.js
@@ -1,7 +1,0 @@
-import Route from '@ember/routing/route';
-
-export default Route.extend({
-  model() {
-    return this.store.findAll('student');
-  }
-});

--- a/frontend/app/templates/companies.hbs
+++ b/frontend/app/templates/companies.hbs
@@ -14,36 +14,39 @@
           selected=selectedItem
           searchField="name"
           labelPath="name"
-          onSelectionChange=(action (mut selectedItem)) as |company autocomplete|}}
+          onSelectionChange=(action (mut selectedItem))
+        as |company autocomplete|
+        }}
           <span class="item-title">
             {{paper-icon "star"}}
             <span>
               {{paper-autocomplete-highlight
                 label=company.name
                 searchText=autocomplete.searchText
-                flags="i"}}
+                flags="i"
+	             }}
             </span>
           </span>
-          {{else}}
+        {{else}}
           <p>
             Whoops! Looks like we don't have that company in the database yet!
           </p>
         {{/paper-autocomplete}}
       </p>
       {{#card.actions}}
-      <div>
-        {{#if selectedItem}}
-          {{#link-to "companies.company.coop-positions" selectedItem.id}}
+        <div>
+          {{#if selectedItem}}
+            {{#link-to "companies.company.coop-positions" selectedItem.id}}
+              {{#paper-button}}
+                search positions
+              {{/paper-button}}
+            {{/link-to}}
+          {{else}}
             {{#paper-button}}
-            search positions
+              search positions
             {{/paper-button}}
-          {{/link-to}}
-        {{else}}
-          {{#paper-button}}
-            search positions
-          {{/paper-button}}
-        {{/if}}
-      </div>
+          {{/if}}
+        </div>
       {{/card.actions}}
     {{/card.content}}
   {{/paper-card}}

--- a/frontend/app/templates/companies.hbs
+++ b/frontend/app/templates/companies.hbs
@@ -1,11 +1,52 @@
 <div class="container">
-  <div class="jumbotron">
-    <h1>Welcome!</h1>
-    <p><strong>Rate My Coop</strong> is designed to connect YOU to students who have worked at a company you are interested in. By giving you access to ratings from other students and their associated contact information, you can make informed decisions about your next co-op experience without having to wait for an advisor. Happy hunting!</p>
-  </div>
-  {{#each model as |company|}}
-    <div class="panel-group">{{company.name}}</div>
-  {{/each}}
+  {{#paper-card as |card|}}
+    {{#card.title as |title|}}
+      {{#title.text as |text|}}
+        {{#text.headline}}<h2>Welcome!</h2>{{/text.headline}}
+      {{/title.text}}
+    {{/card.title}}
+    {{#card.content}}
+      <p><strong>Rate My Coop</strong> is designed to connect YOU to students who have worked at a company you are interested in. By giving you access to ratings from other students and their associated contact information, you can make informed decisions about your next co-op experience without having to wait for an advisor. Happy hunting!</p>
+      <p>
+        {{#paper-autocomplete
+          placeholder="Type company name"
+          options=model
+          selected=selectedItem
+          searchField="name"
+          labelPath="name"
+          onSelectionChange=(action (mut selectedItem)) as |company autocomplete|}}
+          <span class="item-title">
+            {{paper-icon "star"}}
+            <span>
+              {{paper-autocomplete-highlight
+                label=company.name
+                searchText=autocomplete.searchText
+                flags="i"}}
+            </span>
+          </span>
+          {{else}}
+          <p>
+            Whoops! Looks like we don't have that company in the database yet!
+          </p>
+        {{/paper-autocomplete}}
+      </p>
+      {{#card.actions}}
+      <div>
+        {{#if selectedItem}}
+          {{#link-to "companies.company.coop-positions" selectedItem.id}}
+            {{#paper-button}}
+            search positions
+            {{/paper-button}}
+          {{/link-to}}
+        {{else}}
+          {{#paper-button}}
+            search positions
+          {{/paper-button}}
+        {{/if}}
+      </div>
+      {{/card.actions}}
+    {{/card.content}}
+  {{/paper-card}}
 </div>
 
 {{outlet}}

--- a/frontend/app/templates/companies/company.hbs
+++ b/frontend/app/templates/companies/company.hbs
@@ -1,0 +1,3 @@
+<h3>{{model.name}}'s Co-op Positions:</h3>
+
+{{outlet}}

--- a/frontend/app/templates/companies/company/coop-positions.hbs
+++ b/frontend/app/templates/companies/company/coop-positions.hbs
@@ -1,20 +1,20 @@
 <ul>
-{{#each model as |model|}}
-<li>
-  {{model.positionTitle}}
-</li>
-<li>
-  {{model.review}}
-</li>
-<li>
-  {{model.starRating}}
-</li>
-<li>
-  {{#link-to "companies.company.coop-positions.coop-position.students" model}}
-  Check out the students who have worked here
-  {{/link-to}}
-</li>
-{{/each}}
+  {{#each model as |model|}}
+    <li>
+      {{model.positionTitle}}
+    </li>
+    <li>
+      {{model.review}}
+    </li>
+    <li>
+      {{model.starRating}}
+    </li>
+    <li>
+      {{#link-to "companies.company.coop-positions.coop-position.students" model}}
+        Check out the students who have worked here
+      {{/link-to}}
+    </li>
+  {{/each}}
 </ul>
 
 {{outlet}}

--- a/frontend/app/templates/companies/company/coop-positions.hbs
+++ b/frontend/app/templates/companies/company/coop-positions.hbs
@@ -1,0 +1,13 @@
+<ul>
+{{#each model as |model|}}
+<li>
+  {{model.positionTitle}}
+  <br>
+  {{#link-to "companies.company.coop-positions.coop-position" model}}
+  Check out the students who have worked here
+  {{/link-to}}
+</li>
+{{/each}}
+</ul>
+
+{{outlet}}

--- a/frontend/app/templates/companies/company/coop-positions.hbs
+++ b/frontend/app/templates/companies/company/coop-positions.hbs
@@ -2,8 +2,15 @@
 {{#each model as |model|}}
 <li>
   {{model.positionTitle}}
-  <br>
-  {{#link-to "companies.company.coop-positions.coop-position" model}}
+</li>
+<li>
+  {{model.review}}
+</li>
+<li>
+  {{model.starRating}}
+</li>
+<li>
+  {{#link-to "companies.company.coop-positions.coop-position.students" model}}
   Check out the students who have worked here
   {{/link-to}}
 </li>

--- a/frontend/app/templates/companies/company/coop-positions/coop-position.hbs
+++ b/frontend/app/templates/companies/company/coop-positions/coop-position.hbs
@@ -1,6 +1,1 @@
-<h1>Coop position:</h1>
-
-<div>{{model.positionTitle}}</div>
-<div>{{model.review}}</div>
-
 {{outlet}}

--- a/frontend/app/templates/companies/company/coop-positions/coop-position.hbs
+++ b/frontend/app/templates/companies/company/coop-positions/coop-position.hbs
@@ -1,0 +1,6 @@
+<h1>Coop position:</h1>
+
+<div>{{model.positionTitle}}</div>
+<div>{{model.review}}</div>
+
+{{outlet}}

--- a/frontend/app/templates/companies/company/coop-positions/coop-position/students.hbs
+++ b/frontend/app/templates/companies/company/coop-positions/coop-position/students.hbs
@@ -1,2 +1,12 @@
 <h3>Students: </h3>
+<p>Right now we only show one student :) hehe </p>
+<ul>
+  <li>
+    {{model.name}}
+  </li>
+  <li>
+    {{model.contact}}
+  </li>
+</ul>
+
 {{outlet}}

--- a/frontend/app/templates/companies/company/coop-positions/coop-position/students.hbs
+++ b/frontend/app/templates/companies/company/coop-positions/coop-position/students.hbs
@@ -1,0 +1,2 @@
+<h3>Students: </h3>
+{{outlet}}

--- a/frontend/app/templates/students.hbs
+++ b/frontend/app/templates/students.hbs
@@ -1,3 +1,0 @@
-  {{#each model as |student|}}
-    <div class="panel-group">{{student.name}}</div>
-  {{/each}}

--- a/frontend/tests/unit/routes/companies/company-test.js
+++ b/frontend/tests/unit/routes/companies/company-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | companies/company', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:companies/company');
+    assert.ok(route);
+  });
+});

--- a/frontend/tests/unit/routes/companies/company/coop-positions-test.js
+++ b/frontend/tests/unit/routes/companies/company/coop-positions-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | companies/company/coop-positions', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:companies/company/coop-positions');
+    assert.ok(route);
+  });
+});

--- a/frontend/tests/unit/routes/companies/company/coop-positions/coop-position-test.js
+++ b/frontend/tests/unit/routes/companies/company/coop-positions/coop-position-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | companies/company/coop-positions/coop-position', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:companies/company/coop-positions/coop-position');
+    assert.ok(route);
+  });
+});

--- a/frontend/tests/unit/routes/companies/company/coop-positions/coop-position/students-test.js
+++ b/frontend/tests/unit/routes/companies/company/coop-positions/coop-position/students-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | companies/company/coop-positions/coop-position/students', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:companies/company/coop-positions/coop-position/students');
+    assert.ok(route);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4 @@
+{
+  "name": "rate-my-coop",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Added nested route system to frontend. Instead of having two routes (`/companies` and `/students`), we now have multiple routes in this hierarchy:
`/companies/company/coop-positions/coop-position/students`
This separates the logic for each model/route

| 👑 | @ashnashah123 |
| :--- | :--- |
| 🖇 | @ratemycoop |